### PR TITLE
Windows bring up

### DIFF
--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -226,7 +226,7 @@ struct @(trait_class)< @(cpp_full_name_with_alloc) >
 {
   static const char* value()
   {
-    return "@(trait_value)";
+    return @(trait_value);
   }
 
   static const char* value(const @(cpp_full_name_with_alloc)&) { return value(); }

--- a/src/gencpp/__init__.py
+++ b/src/gencpp/__init__.py
@@ -99,7 +99,7 @@ def escape_message_definition(definition):
     s = StringIO()
     for line in lines:
         line = _escape_string(line)
-        s.write('%s\\n\\\n'%(line))
+        s.write('"%s\\n"\n'%(line))
         
     val = s.getvalue()
     s.close()


### PR DESCRIPTION
MSVC complains the literal string too long to contain the message definitions. Break it down into multiple strings.